### PR TITLE
fix: use existing :latest source tags in vm-tools workflow

### DIFF
--- a/.github/workflows/update-vm-tools.yml
+++ b/.github/workflows/update-vm-tools.yml
@@ -23,19 +23,19 @@ jobs:
       matrix:
         include:
           - name: tahoe
-            source_tag: base
+            source_tag: latest
             tag: latest
             disk_gb: 90
           # - name: tahoe
-          #   source_tag: base-200-gb
+          #   source_tag: 200-gb
           #   tag: 200-gb
           #   disk_gb: 200
           # - name: sequoia
-          #   source_tag: base
+          #   source_tag: latest
           #   tag: latest
           #   disk_gb: 90
           # - name: sequoia
-          #   source_tag: base-200-gb
+          #   source_tag: 200-gb
           #   tag: 200-gb
           #   disk_gb: 200
           # - name: sonoma
@@ -43,7 +43,7 @@ jobs:
           #   tag: latest
           #   disk_gb: 90
           # - name: monterey
-          #   source_tag: base
+          #   source_tag: latest
           #   tag: latest
           #   disk_gb: 90
     defaults:


### PR DESCRIPTION
The workflow was using `:base` / `:base-200-gb` as source tags, which don't exist in GHCR. Images are currently published under `:latest` and `:200-gb`. Updating source tags to match what's actually there.

Non-tahoe matrix entries remain commented out pending smoke test passing on tahoe:latest.