### PR TITLE
fix: use sysadminctl for password reset on macOS 26 (Tahoe)

### DIFF
--- a/.github/workflows/update-vm-tools.yml
+++ b/.github/workflows/update-vm-tools.yml
@@ -26,26 +26,22 @@ jobs:
             source_tag: latest
             tag: latest
             disk_gb: 90
-          # - name: tahoe
-          #   source_tag: 200-gb
-          #   tag: 200-gb
-          #   disk_gb: 200
-          # - name: sequoia
-          #   source_tag: latest
-          #   tag: latest
-          #   disk_gb: 90
-          # - name: sequoia
-          #   source_tag: 200-gb
-          #   tag: 200-gb
-          #   disk_gb: 200
-          # - name: sonoma
-          #   source_tag: "14.6"
-          #   tag: latest
-          #   disk_gb: 90
-          # - name: monterey
-          #   source_tag: latest
-          #   tag: latest
-          #   disk_gb: 90
+          - name: tahoe
+            source_tag: 200-gb
+            tag: 200-gb
+            disk_gb: 200
+          - name: sequoia
+            source_tag: latest
+            tag: latest
+            disk_gb: 90
+          - name: sequoia
+            source_tag: 200-gb
+            tag: 200-gb
+            disk_gb: 200
+          - name: sonoma
+            source_tag: "14.6"
+            tag: latest
+            disk_gb: 90
     defaults:
       run:
         shell: bash

--- a/.github/workflows/update-vm-tools.yml
+++ b/.github/workflows/update-vm-tools.yml
@@ -110,10 +110,12 @@ jobs:
         env:
           VM_DEFAULT_PASSWORD: ${{ secrets.VM_DEFAULT_PASSWORD }}
         run: |
+          # dscl . -passwd requires the old password even as root on macOS 26 (Tahoe),
+          # so use sysadminctl which accepts explicit credentials.
           sshpass -p "${VM_DEFAULT_PASSWORD}" \
             ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
             "admin@${{ steps.vm-ip.outputs.VM_IP }}" \
-            "echo ${VM_DEFAULT_PASSWORD} | sudo -S dscl . -passwd /Users/admin admin"
+            "echo ${VM_DEFAULT_PASSWORD} | sudo -S sysadminctl -resetPasswordFor admin -newPassword admin -adminUser admin -adminPassword ${VM_DEFAULT_PASSWORD}"
 
       - name: Reboot VM
         continue-on-error: true


### PR DESCRIPTION
`dscl . -passwd` now requires the old password even as root on macOS 26 (Tahoe). Replacing with `sysadminctl -resetPasswordFor` which accepts explicit admin credentials and works correctly.

Also uncomments the tahoe:200-gb, sequoia, and sonoma matrix entries that were left commented in PR #25. Monterey excluded, not supported per the compatibility matrix.