### PR TITLE
feat: add images filter input to update-vm-tools workflow

### DIFF
--- a/.github/workflows/update-vm-tools.yml
+++ b/.github/workflows/update-vm-tools.yml
@@ -7,6 +7,10 @@ on:
         description: 'Version of orka-vm-tools to install (e.g., 3.6.0)'
         required: false
         default: '3.6.0'
+      images:
+        description: 'Comma-separated list of images to update (e.g., sequoia,sonoma). Leave blank to update all.'
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -15,6 +19,7 @@ permissions:
 jobs:
   update:
     name: ${{ matrix.name }}:${{ matrix.tag }}
+    if: inputs.images == '' || contains(inputs.images, matrix.name)
     runs-on:
       - self-hosted
       - arm-mini-002


### PR DESCRIPTION
## Summary

- Adds an `images` workflow_dispatch input (comma-separated, e.g. `sequoia,sonoma`)
- When blank, all five matrix entries run as before
- When set, only matrix entries whose `name` matches are run

## Test plan

- [ ] Trigger with `images: sequoia,sonoma` — only sequoia and sonoma jobs should run, tahoe should be skipped
- [ ] Trigger with blank `images` — all five jobs should run as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)