### PR TITLE
fix: launchctl load before kickstart for SSH and screen sharing on macOS 26

### DIFF
--- a/.github/workflows/update-vm-tools.yml
+++ b/.github/workflows/update-vm-tools.yml
@@ -111,11 +111,13 @@ jobs:
 
       - name: Run setup
         if: env.SKIP_IMAGE != 'true'
+        timeout-minutes: 15
         env:
           VM_DEFAULT_PASSWORD: ${{ secrets.VM_DEFAULT_PASSWORD }}
         run: |
           sshpass -p "${VM_DEFAULT_PASSWORD}" \
             ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o ServerAliveInterval=30 -o ServerAliveCountMax=3 \
             "admin@${{ steps.vm-ip.outputs.VM_IP }}" \
             "ORKA_VM_TOOLS_VERSION=${{ inputs.vmToolsVersion }} VM_DEFAULT_PASSWORD=${{ secrets.VM_DEFAULT_PASSWORD }} bash ~/setup.sh"
 

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -90,7 +90,7 @@ configure_remote_access() {
 
     # Remote Login (SSH)
     if [[ "$macos_major" -ge 26 ]]; then
-        sudo_run launchctl enable system/com.openssh.sshd
+        sudo_run launchctl load -w /System/Library/LaunchDaemons/ssh.plist || true
         sudo_run launchctl kickstart -k system/com.openssh.sshd
     else
         sudo_run systemsetup -setremotelogin on
@@ -98,11 +98,9 @@ configure_remote_access() {
     fi
 
     # Screen Sharing
+    sudo_run launchctl load -w /System/Library/LaunchDaemons/com.apple.screensharing.plist || true
     if [[ "$macos_major" -ge 26 ]]; then
-        sudo_run launchctl enable system/com.apple.screensharing
         sudo_run launchctl kickstart -k system/com.apple.screensharing
-    else
-        sudo_run launchctl load -w /System/Library/LaunchDaemons/com.apple.screensharing.plist || true
     fi
 
     # Remote Management (ARD/VNC)


### PR DESCRIPTION
## Summary

- On macOS 26, `launchctl enable system/com.openssh.sshd` fails with `could not find service` on a fresh VM because the service isn't bootstrapped into launchd yet. `launchctl enable` requires the service to already be registered.
- Replaces `launchctl enable` with `launchctl load -w`, which registers and enables the service in one step. `launchctl kickstart` then starts it immediately.
- Same fix applied to screen sharing: collapsed the duplicate version branches since both now use `launchctl load -w`, with `kickstart` only on macOS 26+.

Verified on macOS 26.5.1: `ssh.plist` is present at `/System/Library/LaunchDaemons/ssh.plist` with label `com.openssh.sshd`.

## Test plan

- [ ] Run `setup/setup.sh` on a fresh macOS 26 VM and confirm SSH is accessible after completion
- [ ] Confirm screen sharing also comes up correctly on macOS 26
- [ ] Confirm no regression on pre-26 macOS (systemsetup path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)