### PR TITLE
fix: harden setup step and clear shell history on image capture

### DIFF
--- a/.github/workflows/update-vm-tools.yml
+++ b/.github/workflows/update-vm-tools.yml
@@ -66,6 +66,8 @@ jobs:
             echo "orka-engine not found on runner. Register an arm-mini-002 runner with orka-engine pre-installed." >&2
             exit 1
           fi
+          echo "Runner audit session:"
+          launchctl procinfo $$ | grep -i "session id"
 
       - name: Set VM name
         if: env.SKIP_IMAGE != 'true'

--- a/.github/workflows/update-vm-tools.yml
+++ b/.github/workflows/update-vm-tools.yml
@@ -66,8 +66,6 @@ jobs:
             echo "orka-engine not found on runner. Register an arm-mini-002 runner with orka-engine pre-installed." >&2
             exit 1
           fi
-          echo "Runner audit session:"
-          sudo launchctl procinfo $$ | grep -i "session id"
 
       - name: Set VM name
         if: env.SKIP_IMAGE != 'true'
@@ -88,15 +86,6 @@ jobs:
           orka-engine vm run ${{ steps.vars.outputs.VM_NAME }} \
             --image ghcr.io/macstadium/orka-images/${{ matrix.name }}:${{ matrix.source_tag }} \
             -d
-
-      - name: Diagnose VM state
-        if: env.SKIP_IMAGE != 'true'
-        run: |
-          for i in 1 2 3 4 5; do
-            echo "--- t=${i}s ---"
-            orka-engine vm list -o json 2>&1 | jq -r '.[] | "\(.name) ip=\(.ip // "none") state=\(.state // "unknown")"' || true
-            sleep 1
-          done
 
       - name: Wait for VM IP
         if: env.SKIP_IMAGE != 'true'
@@ -122,11 +111,13 @@ jobs:
 
       - name: Run setup
         if: env.SKIP_IMAGE != 'true'
+        timeout-minutes: 15
         env:
           VM_DEFAULT_PASSWORD: ${{ secrets.VM_DEFAULT_PASSWORD }}
         run: |
           sshpass -p "${VM_DEFAULT_PASSWORD}" \
             ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -o ServerAliveInterval=30 -o ServerAliveCountMax=3 \
             "admin@${{ steps.vm-ip.outputs.VM_IP }}" \
             "ORKA_VM_TOOLS_VERSION=${{ inputs.vmToolsVersion }} VM_DEFAULT_PASSWORD=${{ secrets.VM_DEFAULT_PASSWORD }} bash ~/setup.sh"
 

--- a/.github/workflows/update-vm-tools.yml
+++ b/.github/workflows/update-vm-tools.yml
@@ -67,7 +67,7 @@ jobs:
             exit 1
           fi
           echo "Runner audit session:"
-          launchctl procinfo $$ | grep -i "session id"
+          sudo launchctl procinfo $$ | grep -i "session id"
 
       - name: Set VM name
         if: env.SKIP_IMAGE != 'true'

--- a/.github/workflows/update-vm-tools.yml
+++ b/.github/workflows/update-vm-tools.yml
@@ -89,6 +89,15 @@ jobs:
             --image ghcr.io/macstadium/orka-images/${{ matrix.name }}:${{ matrix.source_tag }} \
             -d
 
+      - name: Diagnose VM state
+        if: env.SKIP_IMAGE != 'true'
+        run: |
+          for i in 1 2 3 4 5; do
+            echo "--- t=${i}s ---"
+            orka-engine vm list -o json 2>&1 | jq -r '.[] | "\(.name) ip=\(.ip // "none") state=\(.state // "unknown")"' || true
+            sleep 1
+          done
+
       - name: Wait for VM IP
         if: env.SKIP_IMAGE != 'true'
         timeout-minutes: 5

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -112,6 +112,11 @@ configure_remote_access() {
     log "Remote access configured"
 }
 
+clear_shell_history() {
+    log "Clearing shell history..."
+    rm -f ~/.zsh_history ~/.bash_history
+}
+
 main() {
     log "=== MacOS Orka VM Setup Started ==="
     echo ""
@@ -119,6 +124,7 @@ main() {
     install_orka_vm_tools
     setup_sys_daemon
     configure_remote_access
+    clear_shell_history
 
     echo ""
     log "=== Automated Setup Completed ==="


### PR DESCRIPTION
## Summary

- Adds a `clear_shell_history` step to `setup.sh` that removes `~/.zsh_history` and `~/.bash_history` before image capture, preventing build session commands from appearing in published images
- Adds `timeout-minutes: 15` and SSH `ServerAliveInterval`/`ServerAliveCountMax` to the Run setup step so the job fails fast on a dropped connection instead of hanging indefinitely

## Test plan

- [x] Run the workflow with `images: sonoma` to confirm setup completes and history files are absent in the saved image
- [x] Confirm the workflow fails cleanly (not hangs) if the SSH connection to the VM drops during setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)